### PR TITLE
feat: Improve meeting req filter to not show request made by the curr…

### DIFF
--- a/cypress/e2e/pageLoad.cy.ts
+++ b/cypress/e2e/pageLoad.cy.ts
@@ -114,6 +114,6 @@ describe("Page Load", () => {
     cy.get(".meeting-card").should("have.length", 2);
     cy.get(".meetings-toggle").click();
     cy.get(".meetings-title").should("have.text", "My Meeting Requests");
-    cy.get(".meeting-card-request").should("have.length", 2); 
+    cy.get(".meeting-card-request").should("have.length", 0); 
   });
 });

--- a/src/Components/MeetingRequests/MeetingRequests.tsx
+++ b/src/Components/MeetingRequests/MeetingRequests.tsx
@@ -14,7 +14,9 @@ export function MeetingRequests({
   updateIsAccepted,
 }: MeetingsProps) {
   const meetingRequests = meetings.filter(
-    (meeting) => meeting.attributes.is_accepted !== true
+    (meeting) => (meeting.attributes.is_accepted !== true) && (meeting.attributes.is_host !== true)
+    // so there is already a filter, but I need to differentiate between if *on currentUser dash, if host !== currentUser*
+    // this could be where I use a 'pending' component as the else condition
   );
   // accept handler => sends meetings patch
   const handleAccept = (meetingId: number) => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -11,7 +11,7 @@ export interface Meeting {
     date: string;
     start_time: string;
     end_time: string;
-    is_host: string;
+    is_host: Boolean;
     is_accepted: Boolean
   };
 }


### PR DESCRIPTION

### Summary:

added aditional condition to meeting requests filter, that prevents meeting reqs that the current user made from showing on their dashboard (in the meetings req component)

- File(s) added/changed: MeetingRequests
- Description: added pseudocode for later iteration, added condition to filter()

### Type of change

- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Comment:

### Checklist:

- [x]  Code needs to be tested
- [ ]  All tests are passing
